### PR TITLE
Add line to Gemfile.lock for heroku troubleshooting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -243,6 +245,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)


### PR DESCRIPTION
This PR does the following:
1. Adds a line to Gemfile.lock by running "bundle lock --add-platform x86_64-linux"

Wes
